### PR TITLE
PackageUtilities.getPackages Accepts Multiple Locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Let's use `babel` as an example.
 
 **Note:** Circular dependencies result in circular symlinks which *may* impact your editor/IDE.
 
-[Webstorm](https://www.jetbrains.com/webstorm/) locks up when circular symlinks are present. To prevent this, add `node_modules` to the list of ignored files and folders in `Preferences | Editor | File Types | Ignored files and folders`.  
+[Webstorm](https://www.jetbrains.com/webstorm/) locks up when circular symlinks are present. To prevent this, add `node_modules` to the list of ignored files and folders in `Preferences | Editor | File Types | Ignored files and folders`.
 
 ### publish
 
@@ -423,6 +423,12 @@ Running `lerna` without arguments will show all commands/options.
   },
   "linkedFiles": {
     "prefix": "/**\n * @flow\n */"
+  },
+  "bootstrapConfig": {
+    "ignore": "component-*",
+    "extraPackagesLocations": [
+      "otherFolderLocation"
+    ]
   }
 }
 ```
@@ -431,6 +437,8 @@ Running `lerna` without arguments will show all commands/options.
 - `version`: the current version of the repository.
 - `publishConfig.ignore`: an array of globs that won't be included in `lerna updated/publish`. Use this to prevent publishing a new version unnecessarily for changes, such as fixing a `README.md` typo.
 - `linkedFiles.prefix`: a prefix added to linked dependency files.
+- `bootstrapConfig.ignore`: a glob to exclude a subset of packages when running the `bootstrap` command.
+- `bootstrapConfig.extraPackagesLocations`: an array of folder paths for other package locations.
 
 ### Common `devDependencies`
 

--- a/src/Command.js
+++ b/src/Command.js
@@ -101,7 +101,7 @@ export default class Command {
 
   runPreparations() {
     try {
-      this.packages = PackageUtilities.getPackages(this.repository.packagesLocation);
+      this.packages = PackageUtilities.getPackages(this.repository.packagesLocation, ...this.repository.extraPackagesLocations);
       this.packageGraph = PackageUtilities.getPackageGraph(this.packages);
     } catch (err) {
       this.logger.error("Errored while collecting packages and package graph", err);

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -27,16 +27,25 @@ export default class PackageUtilities {
     return require(PackageUtilities.getPackageConfigPath(packagesPath, name));
   }
 
-  static getPackages(packagesPath) {
+  static getPackages(...packagesPaths) {
     const packages = [];
 
-    FileSystemUtilities.readdirSync(packagesPath).forEach((packageDirectory) => {
+    packagesPaths.forEach(
+      (path) => packages.push(...PackageUtilities.getPackageInPath(path))
+    );
+
+    return packages;
+  }
+
+  static getPackageInPath(path) {
+    const packages = [];
+    FileSystemUtilities.readdirSync(path).forEach((packageDirectory) => {
       if (packageDirectory[0] === ".") {
         return;
       }
 
-      const packagePath = PackageUtilities.getPackagePath(packagesPath, packageDirectory);
-      const packageConfigPath = PackageUtilities.getPackageConfigPath(packagesPath, packageDirectory);
+      const packagePath = PackageUtilities.getPackagePath(path, packageDirectory);
+      const packageConfigPath = PackageUtilities.getPackageConfigPath(path, packageDirectory);
 
       if (!FileSystemUtilities.existsSync(packageConfigPath)) {
         return;
@@ -45,9 +54,8 @@ export default class PackageUtilities {
       const packageJson = require(packageConfigPath);
       const pkg = new Package(packageJson, packagePath);
 
-      packages.push(pkg);
+      return packages.push(pkg);
     });
-
     return packages;
   }
 

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -43,6 +43,12 @@ export default class Repository {
     return this.lernaJson && this.lernaJson.bootstrapConfig || {};
   }
 
+  get extraPackagesLocations() {
+    const extraLocations = this.lernaJson && this.lernaJson.bootstrapConfig
+      && this.lernaJson.bootstrapConfig.extraPackagesLocations || [];
+    return extraLocations.map((loc) => path.join(this.rootPath, loc));
+  }
+
   isIndependent() {
     return this.version === "independent";
   }

--- a/test/PackageUtilities.js
+++ b/test/PackageUtilities.js
@@ -57,6 +57,31 @@ describe("PackageUtilities", () => {
       assert.equal(result[0].version, "1.0.0");
       assert.equal(result[0].location, path.join(fixture, "package-1"));
     });
+
+    it("should collect all the packages from all provided directories", () => {
+      const fixturePackages = path.join(__dirname, "fixtures/PackageUtilities/extraPackageLocations/packages");
+      const fixtureOtherPackages = path.join(__dirname, "fixtures/PackageUtilities/extraPackageLocations/otherPackages");
+      const result = PackageUtilities.getPackages(fixturePackages, fixtureOtherPackages);
+
+      assert.equal(result.length, 4);
+      assert(result[0] instanceof Package);
+      assert.equal(result[0].name, "package-1");
+      assert.equal(result[0].version, "1.0.0");
+      assert.equal(result[0].location, path.join(fixturePackages, "package-1"));
+    });
+  });
+
+  describe(".getPackageInPath()", () => {
+    it("should collect all the packages from the given packages directory", () => {
+      const fixture = path.join(__dirname, "fixtures/PackageUtilities/basic/packages");
+      const result = PackageUtilities.getPackageInPath(fixture);
+
+      assert.equal(result.length, 4);
+      assert(result[0] instanceof Package);
+      assert.equal(result[0].name, "package-1");
+      assert.equal(result[0].version, "1.0.0");
+      assert.equal(result[0].location, path.join(fixture, "package-1"));
+    });
   });
 
   describe(".filterPackages()", () => {

--- a/test/fixtures/PackageUtilities/extraPackageLocations/lerna.json
+++ b/test/fixtures/PackageUtilities/extraPackageLocations/lerna.json
@@ -1,0 +1,9 @@
+{
+  "lerna": "__TEST_VERSION__",
+  "version": "1.0.0",
+  "bootstrapConfig": {
+    "extraPackagesLocations": [
+      "otherPackages"
+    ]
+  }
+}

--- a/test/fixtures/PackageUtilities/extraPackageLocations/otherPackages/package-3/package.json
+++ b/test/fixtures/PackageUtilities/extraPackageLocations/otherPackages/package-3/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-3",
+  "version": "1.0.0",
+  "devDependencies": {
+    "package-2": "^1.0.0"
+  }
+}

--- a/test/fixtures/PackageUtilities/extraPackageLocations/otherPackages/package-4/package.json
+++ b/test/fixtures/PackageUtilities/extraPackageLocations/otherPackages/package-4/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-4",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^0.0.0"
+  }
+}

--- a/test/fixtures/PackageUtilities/extraPackageLocations/package.json
+++ b/test/fixtures/PackageUtilities/extraPackageLocations/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/PackageUtilities/extraPackageLocations/packages/package-1/package.json
+++ b/test/fixtures/PackageUtilities/extraPackageLocations/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/PackageUtilities/extraPackageLocations/packages/package-2/package.json
+++ b/test/fixtures/PackageUtilities/extraPackageLocations/packages/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^1.0.0"
+  }
+}


### PR DESCRIPTION
Added a new bootstrapConfig property to allow specifying other locations
for packages. This allows a more flexible project structure.